### PR TITLE
Update Developer Guide to include use cases for copying email addresses v1.1

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -439,11 +439,32 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions**
 
-*    5a. No persons match the search criteria.
+*   5a. No persons match the search criteria.
 
-*   5a1. AddressBook displays a message indicating that no persons match the criteria.
+    * 5a1. AddressBook displays a message indicating that no persons match the criteria.
 
-Use case ends.
+    Use case ends.
+
+**Use case: Copy**
+
+**MSS**
+
+1.  User requests to copy emails of currently displayed persons.
+2.  AddressBook copies the emails of currently displayed persons 
+into user's clipboard.
+3.  AddressBook notifies the user that emails have been copied.
+4.  User can paste emails when composing emails.
+
+    Use case ends.
+
+**Extensions**
+
+*   2a. No persons currently displayed.
+
+    * 2a1. AddressBook displays a message indicating that 
+    no persons are currently displayed.
+
+    Use case ends.
 
 **Use case: Clear**
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -449,8 +449,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **MSS**
 
-1.  User requests to copy emails of currently displayed persons.
-2.  AddressBook copies the emails of currently displayed persons 
+1.  User requests to copy emails of currently displayed contacts.
+2.  AddressBook copies the emails of currently displayed contacts 
 into user's clipboard.
 3.  AddressBook notifies the user that emails have been copied.
 4.  User can paste emails when composing emails.
@@ -459,10 +459,10 @@ into user's clipboard.
 
 **Extensions**
 
-*   2a. No persons currently displayed.
+*   2a. No contacts currently displayed.
 
     * 2a1. AddressBook displays a message indicating that 
-    no persons are currently displayed.
+    no contacts are currently displayed.
 
     Use case ends.
 


### PR DESCRIPTION
Update Developer Guide

The developer guide has been updated to include use cases for copying emails.

This allows future developers to understand better how the 'copy' function interacts with users.

fixes #98