### PR TITLE
Improve explaination for prefixes and find command in User Guide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -103,7 +103,7 @@ How the `Logic` component works:
 
 1. When `Logic` is called upon to execute a command, it is passed to an `AddressBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteCommandParser`) and uses it to parse the command.
 1. This results in a `Command` object (more precisely, an object of one of its subclasses e.g., `DeleteCommand`) which is executed by the `LogicManager`.
-1. The command can communicate with the `Model` when it is executed (e.g. to delete a contact).<br>
+1. The command can communicate with the `Model` when it is executed (e.g. to delete a person).<br>
    Note that although this is shown as a single step in the diagram above (for simplicity), in the code it can take several interactions (between the command object and the `Model`) to achieve.
 1. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `Logic`.
 
@@ -176,11 +176,11 @@ Step 1. The user launches the application for the first time. The `VersionedAddr
 
 <puml src="diagrams/UndoRedoState0.puml" alt="UndoRedoState0" />
 
-Step 2. The user executes `delete 5` command to delete the 5th contact in the address book. The `delete` command calls `Model#commitAddressBook()`, causing the modified state of the address book after the `delete 5` command executes to be saved in the `addressBookStateList`, and the `currentStatePointer` is shifted to the newly inserted address book state.
+Step 2. The user executes `delete 5` command to delete the 5th person in the address book. The `delete` command calls `Model#commitAddressBook()`, causing the modified state of the address book after the `delete 5` command executes to be saved in the `addressBookStateList`, and the `currentStatePointer` is shifted to the newly inserted address book state.
 
 <puml src="diagrams/UndoRedoState1.puml" alt="UndoRedoState1" />
 
-Step 3. The user executes `add n/David …​` to add a new contact. The `add` command also calls `Model#commitAddressBook()`, causing another modified address book state to be saved into the `addressBookStateList`.
+Step 3. The user executes `add n/David …​` to add a new person. The `add` command also calls `Model#commitAddressBook()`, causing another modified address book state to be saved into the `addressBookStateList`.
 
 <puml src="diagrams/UndoRedoState2.puml" alt="UndoRedoState2" />
 
@@ -190,7 +190,7 @@ Step 3. The user executes `add n/David …​` to add a new contact. The `add` c
 
 </box>
 
-Step 4. The user now decides that adding the contact was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous address book state, and restores the address book to that state.
+Step 4. The user now decides that adding the person was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous address book state, and restores the address book to that state.
 
 <puml src="diagrams/UndoRedoState3.puml" alt="UndoRedoState3" />
 
@@ -246,7 +246,7 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 * **Alternative 2:** Individual command knows how to undo/redo by
   itself.
-    * Pros: Will use less memory (e.g. for `delete`, just save the contact being deleted).
+    * Pros: Will use less memory (e.g. for `delete`, just save the person being deleted).
     * Cons: We must ensure that the implementation of each individual command are correct.
 
 _{more aspects and alternatives to be added}_
@@ -283,7 +283,7 @@ _{Explain here how the data archiving feature will be implemented}_
 * has a need to schedule classes
 * has a need to coordinate with teaching assistants
 * has a need to effectively communicate with students
-* has a need to manage a significant number of contacts
+* has a need to manage a significant number of persons
 * prefer desktop apps over other types
 * can type fast
 * prefers typing to mouse interactions
@@ -291,9 +291,9 @@ _{Explain here how the data archiving feature will be implemented}_
 
 **Value proposition**:
 
-* manage contacts faster than a typical mouse/GUI driven app
-* Centralised platform to store and manage contact details for all relevant individuals involved in course administration
-* Easier access to information through organising relevant contacts into different subgroups
+* manage persons faster than a typical mouse/GUI driven app
+* Centralised platform to store and manage person details for all relevant individuals involved in course administration
+* Easier access to information through organising relevant persons into different subgroups
 * Direct linkages to students’ schoolwork for easier tracking
 * Able to set up the address book through different data-loading options
 * Able to assist with management of large scale communication
@@ -309,24 +309,24 @@ _{Explain here how the data archiving feature will be implemented}_
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a …​                                     | I want to …​                           | So that I can…​                                                         |
+| Priority | As a …​                                      | I want to …​                            | So that I can…​                                                          |
 |----------|---------------------------------------------|----------------------------------------|-------------------------------------------------------------------------|
 | `* * *`  | potential user exploring the app            | see the app populated with sample data | immediately see an example of the app in use                            |
 | `* * *`  | new user                                    | easily clear the example data          | start using the app with real-life data                                 |
 | `* * *`  | new user                                    | see usage instructions                 | refer to instructions when I forget how to use the App                  |
-| `* * *`  | new user                                    | add contacts with their details        | start populating the address book                                       |
+| `* * *`  | new user                                    | add persons with their details         | start populating the address book                                       |
 | `* * *`  | new user                                    | save the data I input into the app     | don't lose the information I've entered                                 |
-| `* * *`  | user                                        | add a new contact                      |                                                                         |
-| `* * *`  | user                                        | delete a contact                       | remove entries that I no longer need                                    |
-| `* * *`  | user                                        | update and edit contact details        | keep my address book accurate                                           |
-| `* * *`  | user                                        | find a contact by name                 | locate details of contacts without having to go through the entire list |
-| `* * *`  | user                                        | find a contact by name                 | locate details of contacts without having to go through the entire list |
-| `* * *`  | head tutor using the app                    | categorise my contacts into groups     | manage different tutorial groups effectively                            |
+| `* * *`  | user                                        | add a new person                       |                                                                         |
+| `* * *`  | user                                        | delete a person                        | remove entries that I no longer need                                    |
+| `* * *`  | user                                        | update and edit person details         | keep my address book accurate                                           |
+| `* * *`  | user                                        | find a person by name                  | locate details of persons without having to go through the entire list  |
+| `* * *`  | user                                        | find a person by name                  | locate details of persons without having to go through the entire list  |
+| `* * *`  | head tutor using the app                    | categorise my persons into groups      | manage different tutorial groups effectively                            |
 | `* * *`  | head tutor using the app                    | copy email addresses of a group        | effectively communicate with target groups                              |
-| `* * *`  | user                                        | find a contact by name                 | locate details of contacts without having to go through the entire list |
-| `* *`    | user                                        | hide private contact details           | minimize chance of someone else seeing them by accident                 |
+| `* * *`  | user                                        | find a person by name                  | locate details of persons without having to go through the entire list  |
+| `* *`    | user                                        | hide private person details            | minimize chance of someone else seeing them by accident                 |
 | `* *`    | experienced user                            | use the address book offline           | update and interact with it anywhere                                    |
-| `*`      | user with many contacts in the address book | sort contacts by name                  | locate a contact easily                                                 |
+| `*`      | user with many persons in the address book  | sort persons by name                   | locate a person easily                                                  |
 
 *{More to be added}*
 
@@ -334,14 +334,14 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 (For all use cases below, the **System** is the `AddressBook` and the **Actor** is the `user`, unless specified otherwise)
 
-**Use case: UC01 — Delete a contact**
+**Use case: UC01 — Delete a person**
 
 **MSS:**
 
-1.  User !!requests to list contacts (UC04)!!
-2.  AddressBook shows a list of contacts
-3.  User requests to delete a specific contact in the list
-4.  AddressBook deletes the contact
+1.  User !!requests to list persons (UC04)!!
+2.  AddressBook shows a list of persons
+3.  User requests to delete a specific person in the list
+4.  AddressBook deletes the person
 
     Use case ends.
 
@@ -367,37 +367,37 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-**Use case: UC03 — Add a contact**
+**Use case: UC03 — Add a person**
 
 **MSS:**
 
-1.  User requests to add a new contact and inputs details for the new contact.
-2.  AddressBook saves the new contact's information.
-3.  AddressBook confirms the addition of the new contact.
+1.  User requests to add a new person and inputs details for the new person.
+2.  AddressBook saves the new person's information.
+3.  AddressBook confirms the addition of the new person.
 
     Use case ends.
 
 **Extensions:**
 
-*  1a. User does not input all compulsory parameters along with the contact.
+*  1a. User does not input all compulsory parameters along with the person.
 
     *  1a1. AddressBook prompts the user on the proper usage of the command.
 
         Step 1a1 is repeated until the data entered is correct.
-   
-*  1b. User tries to add a contact with an existing email address.
+
+*  1b. User tries to add a person with an existing email address.
 
     *  1b1. AddressBook displays and error message informing the user that the email address already exists.
-    
+
         Step 1b1 is repeated until a valid email address if entered.
 
-**Use case: UC04 — List all contacts**
+**Use case: UC04 — List all persons**
 
 **MSS:**
 
-1.  User requests to list contacts.
-2.  AddressBook shows the list of contacts.
-3.  User views the list of contacts.
+1.  User requests to list persons.
+2.  AddressBook shows the list of persons.
+3.  User views the list of persons.
 
     Use case ends.
 
@@ -409,11 +409,11 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case ends.
 
-**Use case: UC05 — Edit a contact's details**
+**Use case: UC05 — Edit a person's details**
 
 **MSS:**
 
-1.  User requests to edit a specific contact with updated details.
+1.  User requests to edit a specific person with updated details.
 2.  AddressBook saves the updated details.
 3.  AddressBook confirms the successful update.
 
@@ -421,42 +421,42 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions:**
 
-*   1a. User does not input enough parameters along with the contact.
+*   1a. User does not input enough parameters along with the person.
 
     *  1a1. AddressBook prompts the user on the proper usage of the command.
 
        Step 1a1 is repeated until the data entered is correct.
 
-*   1b. The selected contact does not exist.
+*   1b. The selected person does not exist.
 
-    *  1b1. AddressBook displays an error message indicating that the contact does not exist.
+    *  1b1. AddressBook displays an error message indicating that the person does not exist.
 
       Use case ends.
 
-**Use case: UC06 — Find contacts**
+**Use case: UC06 — Find persons**
 
 **MSS:**
 
-1.  User requests to find a specific contact matching the search criteria.
-2.  AddressBook displays a list of contacts matching the criteria.
+1.  User requests to find a specific person matching the search criteria.
+2.  AddressBook displays a list of persons matching the criteria.
 
     Use case ends.
 
 **Extensions:**
 
-*    1a. No contacts match the search criteria.
+*    1a. No persons match the search criteria.
 
-     *   1a1. AddressBook displays a message indicating that no contacts match the criteria.
+     *   1a1. AddressBook displays a message indicating that no persons match the criteria.
 
      Use case ends.
 
 
-**Use case: UC07 — Import contacts**
+**Use case: UC07 — Import persons**
 
 **MSS**
-1. User requests to import contacts from a csv file.
-2. AddressBook displays a message that all contacts have been imported.
-3. User is able to see all the contacts imported when a list of contacts is requested.
+1. User requests to import persons from a csv file.
+2. AddressBook displays a message that all persons have been imported.
+3. User is able to see all the persons imported when a list of persons is requested.
    Use case ends.
 
 **Extension**
@@ -478,8 +478,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **MSS:**
 
-1.  User requests to copy emails of currently displayed contacts.
-2.  AddressBook copies the emails of currently displayed contacts 
+1.  User requests to copy emails of currently displayed persons.
+2.  AddressBook copies the emails of currently displayed persons
 into user's clipboard.
 3.  AddressBook notifies the user that emails have been copied.
 4.  User can paste emails when composing emails.
@@ -488,20 +488,20 @@ into user's clipboard.
 
 **Extensions:**
 
-*   2a. No contacts currently displayed.
+*   2a. No persons currently displayed.
 
-    * 2a1. AddressBook displays a message indicating that 
-    no contacts are currently displayed.
+    * 2a1. AddressBook displays a message indicating that
+    no persons are currently displayed.
 
     Use case ends.
 
-**Use case: UC09 — Clear all contacts**
+**Use case: UC09 — Clear all persons**
 
 **MSS:**
 
-1.  User requests to clear all contacts.
-2.  AddressBook clears all contacts.
-3.  AddressBook displays a message indicating that all contacts have been cleared.
+1.  User requests to clear all persons.
+2.  AddressBook clears all persons.
+3.  AddressBook displays a message indicating that all persons have been cleared.
 
     Use case ends.
 
@@ -510,17 +510,17 @@ into user's clipboard.
 *    1a. User inputs extraneous parameters.
 
      *   1a1. AddressBook displays a message indicating that an extraneous parameter was found, and confirms User's intention.
-     
+
          Use case ends.
 
-**Use case: UC10 — Export contacts to CSV**
+**Use case: UC10 — Export persons to CSV**
 
 **MSS:**
 
-1.  User requests to export all contacts and details to a CSV file.
-2.  AddressBook exports the contacts to a CSV file.
-3.  AddressBook displays a message to confirm that all contacts have been exported to a CSV file.
-    
+1.  User requests to export all persons and details to a CSV file.
+2.  AddressBook exports the persons to a CSV file.
+3.  AddressBook displays a message to confirm that all persons have been exported to a CSV file.
+
     Use case ends.
 
 **Use case: UC11 — Exit application**
@@ -543,9 +543,9 @@ into user's clipboard.
 ### Non-Functional Requirements
 
 1.   Should work on any _mainstream OS_ as long as it has Java `11` or above installed.
-2.   Should be able to hold up to 1000 contacts without a noticeable sluggishness in performance for typical usage.
+2.   Should be able to hold up to 1000 persons without a noticeable sluggishness in performance for typical usage.
 3.   A user with above average typing speed for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
-4.   A user should be able to import up to 1000 contacts from an external source without a noticeable sluggishness in performance for typical usage.
+4.   A user should be able to import up to 1000 persons from an external source without a noticeable sluggishness in performance for typical usage.
 5.   The application should provide comprehensive documentation and help resources to assist users in understanding how to use the software effectively.
 
 
@@ -554,7 +554,7 @@ into user's clipboard.
 ### Glossary
 
 * **Mainstream OS**: Windows, Linux, Unix, MacOS
-* **Private contact detail**: A contact detail that is not meant to be shared with others
+* **Private person detail**: A person detail that is not meant to be shared with others
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -575,7 +575,7 @@ testers are expected to do more *exploratory* testing.
 
     1. Download the jar file and copy into an empty folder
 
-    1. Double-click the jar file Expected: Shows the GUI with a set of sample contacts. The window size may not be optimum.
+    1. Double-click the jar file Expected: Shows the GUI with a set of sample persons. The window size may not be optimum.
 
 1. Saving window preferences
 
@@ -586,17 +586,17 @@ testers are expected to do more *exploratory* testing.
 
 1. _{ more test cases …​ }_
 
-### Deleting a contact
+### Deleting a person
 
-1. Deleting a contact while all contacts are being shown
+1. Deleting a person while all persons are being shown
 
-    1. Prerequisites: List all contacts using the `list` command. Multiple contacts in the list.
+    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
 
     1. Test case: `delete 1`<br>
-       Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated.
+       Expected: First person is deleted from the list. Details of the deleted person shown in the status message. Timestamp in the status bar is updated.
 
     1. Test case: `delete 0`<br>
-       Expected: No contact is deleted. Error details shown in the status message. Status bar remains the same.
+       Expected: No person is deleted. Error details shown in the status message. Status bar remains the same.
 
     1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
        Expected: Similar to previous.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -48,6 +48,19 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 **Notes about the command format:**<br>
 
+* Some commands require you to include parameters. These parameters are identified by prefixes.
+
+* Here are a list of valid prefixes and what they each refer to.
+
+| Prefix | What it refers to |
+|--------|-------------------|
+|n/| Name of the contact     |
+|p/| Phone number of contact |
+|e/| Email of contact        |
+|a/| Address of contact      |
+|t/| Tags of contact         |
+|m/| Matriculation number of contact|
+
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
@@ -66,16 +79,6 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </box>
 
-### Valid tags:
-
-A list of valid parameters for a contact.
-
-* `n/NAME` 
-* `p/PHONE` 
-* `e/EMAIL` 
-* `a/ADDRESS` 
-* `t/TAG` 
-* `m/MATRIC_ID`
 
 ### Viewing help : `help`
 
@@ -88,16 +91,16 @@ Format: `help`
 
 ### Parameters:
 
-* n/NAME 
-* p/PHONE_NUMBER 
-* e/EMAIL 
-* a/ADDRESS 
+* n/NAME
+* p/PHONE_NUMBER
+* e/EMAIL
+* a/ADDRESS
 * t/TAG (Optional)
 * m/MATRICULATION_NUMBER (Optional)
 
-### Adding a person: `add`
+### Adding a contact: `add`
 
-Adds a person to the address book.
+Adds a contact to the address book.
 
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG] [m/MATRICULATION_NUMBER]…​`
@@ -110,53 +113,54 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG] [m/MATRICULATION_NU
 
 <box type="tip" seamless>
 
-**Tip:** A person can have any number of tags (including 0)
+**Tip:** A contact can have any number of tags (including 0)
 </box>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 m/A1234567Z`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal m/A1234567Z`
 
-### Listing all persons : `list`
+### Listing all contacts : `list`
 
-Shows a list of all persons in the address book.
+Shows a list of all contacts in the address book.
 
 Format: `list`
 
-### Editing a person : `edit`
+### Editing a contact : `edit`
 
-Edits an existing person in the address book.
+Edits an existing contact in the address book.
 
 
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [m/MATRICULATION_NUMBER]…​`
 
-* Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
+* Edits the contact at the specified `INDEX`. The index refers to the index number shown in the displayed contact list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
-* You can remove all the person’s tags by typing `t/` without
+* When editing tags, the existing tags of the contact will be removed i.e adding of tags is not cumulative.
+* You can remove all the contact’s tags by typing `t/` without
     specifying any tags after it.
 
 Examples:
-*  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+*  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st contact to be `91234567` and `johndoe@example.com` respectively.
+*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd contact to be `Betsy Crower` and clears all existing tags.
 
-### Filtering Contacts using parameters: `find`
+### Filtering Contacts: `find`
 
-Finds persons with parameters that match the given keyword
+* Filter contacts based on specific criteria within their records.
 
-Format: `find PARAMETER KEYWORD`
+Format: `find PREFIX/KEYWORD`
 
-* The search is case-insensitive. e.g. `hans` will match `Hans`
-* The search will return any result that contains the keyword as a substring under that parameter. e.g. `hans` will match `hans@gmail.com` for an email search
-* `PARAMETER` that is supported includes : /n, /p, /e, /a and /t
-* Only one parameter can be searched
+* This command searches for contacts using a specific aspect of their details, as specified by the prefix.
+* The search will return any result that contains the keyword as a substring under the indicated prefix. e.g. `find e/hans` will find any contact that contains `hans` in their email.
+* The search is case-insensitive. e.g. `hans` will match `Hans`.
+* prefixes that are supported includes : n/, p/, e/, a/, m/ and t/.
+* Only one prefix can be used for filtering at a time.
 
 Examples:
-* `find \n John` returns `john` and `John Doe`
-* `find \n alex` returns `Alex Yeoh`, `Davis Alex`
-* `find \t student` returns all contacts tagged with `student` or any contacts with tags that has `student` as a substring
-* `find \p 1423` returns all contacts with phone number containing `1423`
+* `find n/John` returns `john` and `John Doe`.
+* `find n/alex` returns `Alex Yeoh`, `Davis Alex`.
+* `find t/student` returns all contacts tagged with `student` or any contacts with tags that has `student` as a substring.
+* `find p/1423` returns all contacts with phone number containing `1423`.
 
 ### Copy email addresses: `copy`
 
@@ -168,19 +172,19 @@ Format: `copy`
 * The emails are copied into your clipboard such that you may easily broadcast emails
   to specific groups of people.
 
-### Deleting a person : `delete`
+### Deleting a contact : `delete`
 
-Deletes the specified person from the address book.
+Deletes the specified contact from the address book.
 
 Format: `delete INDEX`
 
-* Deletes the person at the specified `INDEX`.
-* The index refers to the index number shown in the displayed person list.
+* Deletes the contact at the specified `INDEX`.
+* The index refers to the index number shown in the displayed contact list.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `list` followed by `delete 2` deletes the 2nd person in the address book.
-* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+* `list` followed by `delete 2` deletes the 2nd contact in the address book.
+* `find Betsy` followed by `delete 1` deletes the 1st contact in the results of the `find` command.
 
 ### Clearing all entries : `clear`
 
@@ -222,7 +226,7 @@ If your changes to the data file makes its format invalid, AddressBook will disc
 Furthermore, certain edits can cause the AddressBook to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </box>
 
-### 
+###
 
 ### Archiving data files `[coming in v2.0]`
 
@@ -245,7 +249,7 @@ _Details coming soon ..._
 
 ## Command summary
 
-| Action | Format, Examples                                                                                                                                                                          
+| Action | Format, Examples
 |--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG] [m/MATRICULATION_NUMBER]…​` e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague` |
 | **Clear**  | `clear`                                                                                                                                                                                   |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -28,13 +28,13 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
    Some example commands you can try:
 
-   * `list` : Lists all contacts.
+   * `list` : Lists all persons.
 
-   * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 m/A1234567Z` : Adds a contact named `John Doe` to the Address Book.
+   * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 m/A1234567Z` : Adds a person named `John Doe` to the Address Book.
 
-   * `delete 3` : Deletes the 3rd contact shown in the current list.
+   * `delete 3` : Deletes the 3rd person shown in the current list.
 
-   * `clear` : Deletes all contacts.
+   * `clear` : Deletes all persons.
 
    * `exit` : Exits the app.
 
@@ -52,14 +52,14 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 * Here are a list of valid prefixes and what they each refer to.
 
-| Prefix | What it refers to |
-|--------|-------------------|
-|n/| Name of the contact     |
-|p/| Phone number of contact |
-|e/| Email of contact        |
-|a/| Address of contact      |
-|t/| Tags of contact         |
-|m/| Matriculation number of contact|
+| Prefix | What it refers to         |
+|--------|---------------------------|
+|n/      | Name of the person        |
+|p/      | Phone number of person    |
+|e/      | Email of person           |
+|a/      | Address of person         |
+|t/      | Tags of person            |
+|m/      | Matriculation ID of person|
 
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
@@ -98,60 +98,60 @@ Format: `help`
 * t/TAG (Optional)
 * m/MATRICULATION_NUMBER (Optional)
 
-### Adding a contact: `add`
+### Adding a person: `add`
 
-Adds a contact to the address book.
+Adds a person to the address book.
 
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG] [m/MATRICULATION_NUMBER]…​`
 
 <box type="info" seamless>
 
-**Important:** Each contact should have an unique email address. AB3 does not allow for duplicate email addressed to be added.
+**Important:** Each person should have an unique email address. AB3 does not allow for duplicate email addressed to be added.
 
 </box>
 
 <box type="tip" seamless>
 
-**Tip:** A contact can have any number of tags (including 0)
+**Tip:** A person can have any number of tags (including 0)
 </box>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 m/A1234567Z`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal m/A1234567Z`
 
-### Listing all contacts : `list`
+### Listing all persons : `list`
 
-Shows a list of all contacts in the address book.
+Shows a list of all persons in the address book.
 
 Format: `list`
 
-### Editing a contact : `edit`
+### Editing a person : `edit`
 
-Edits an existing contact in the address book.
+Edits an existing person in the address book.
 
 
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [m/MATRICULATION_NUMBER]…​`
 
-* Edits the contact at the specified `INDEX`. The index refers to the index number shown in the displayed contact list. The index **must be a positive integer** 1, 2, 3, …​
+* Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing tags, the existing tags of the contact will be removed i.e adding of tags is not cumulative.
-* You can remove all the contact’s tags by typing `t/` without
+* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
+* You can remove all the person’s tags by typing `t/` without
     specifying any tags after it.
 
 Examples:
-*  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st contact to be `91234567` and `johndoe@example.com` respectively.
-*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd contact to be `Betsy Crower` and clears all existing tags.
+*  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
+*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
-### Filtering Contacts: `find`
+### Filtering persons: `find`
 
-* Filter contacts based on specific criteria within their records.
+* Filter persons based on specific criteria within their records.
 
 Format: `find PREFIX/KEYWORD`
 
-* This command searches for contacts using a specific aspect of their details, as specified by the prefix.
-* The search will return any result that contains the keyword as a substring under the indicated prefix. e.g. `find e/hans` will find any contact that contains `hans` in their email.
+* This command searches for persons using a specific aspect of their details, as specified by the prefix.
+* The search will return any result that contains the keyword as a substring under the indicated prefix. e.g. `find e/hans` will find any person that contains `hans` in their email.
 * The search is case-insensitive. e.g. `hans` will match `Hans`.
 * prefixes that are supported includes : n/, p/, e/, a/, m/ and t/.
 * Only one prefix can be used for filtering at a time.
@@ -159,12 +159,12 @@ Format: `find PREFIX/KEYWORD`
 Examples:
 * `find n/John` returns `john` and `John Doe`.
 * `find n/alex` returns `Alex Yeoh`, `Davis Alex`.
-* `find t/student` returns all contacts tagged with `student` or any contacts with tags that has `student` as a substring.
-* `find p/1423` returns all contacts with phone number containing `1423`.
+* `find t/student` returns all persons tagged with `student` or any persons with tags that has `student` as a substring.
+* `find p/1423` returns all persons with phone number containing `1423`.
 
 ### Copy email addresses: `copy`
 
-Copies the emails of currently displayed contacts into your clipboard.
+Copies the emails of currently displayed persons into your clipboard.
 
 Format: `copy`
 
@@ -172,19 +172,19 @@ Format: `copy`
 * The emails are copied into your clipboard such that you may easily broadcast emails
   to specific groups of people.
 
-### Deleting a contact : `delete`
+### Deleting a person : `delete`
 
-Deletes the specified contact from the address book.
+Deletes the specified person from the address book.
 
 Format: `delete INDEX`
 
-* Deletes the contact at the specified `INDEX`.
-* The index refers to the index number shown in the displayed contact list.
+* Deletes the person at the specified `INDEX`.
+* The index refers to the index number shown in the displayed person list.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `list` followed by `delete 2` deletes the 2nd contact in the address book.
-* `find Betsy` followed by `delete 1` deletes the 1st contact in the results of the `find` command.
+* `list` followed by `delete 2` deletes the 2nd person in the address book.
+* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
 ### Clearing all entries : `clear`
 
@@ -194,16 +194,16 @@ Format: `clear`
 
 ### Exporting Data to a CSV file : `export to csv`
 
-Exports all contacts and their details to a CSV file.
+Exports all persons and their details to a CSV file.
 
 Format: `export to csv`
 
 ### Importing Data from a CSV file : `import`
 
-Imports all contacts and their details from a CSV file from a specified file path.
+Imports all persons and their details from a CSV file from a specified file path.
 
 Format: `import FILEPATH`
-- imports the contacts saved in `FILEPATH` to `addressBook.json`
+- imports the persons saved in `FILEPATH` to `addressBook.json`
 
 ### Exiting the program : `exit`
 


### PR DESCRIPTION
There is an overlapping usage for the term "parameter" which currently refers to both the prefixes "e/, n/, etc." and the user supplied input of "EMAIL, NAME, etc." which can cause confusion for users. The instructions for the find command are particularly confusing as it requires dynamic usage of prefixes.

Let's update the user guide to be clearer in explaining the usage of prefixes and parameters.

Fixes #128 