### PR TITLE
fix: edit typo and formatting error in developer guide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -384,12 +384,16 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     *  1a1. AddressBook prompts the user on the proper usage of the command.
 
         Step 1a1 is repeated until the data entered is correct.
+        
+        Use case resumes at step 2.
 
 *  1b. User tries to add a person with an existing email address.
 
-    *  1b1. AddressBook displays and error message informing the user that the email address already exists.
+    *  1b1. AddressBook displays an error message informing the user that the email address already exists.
 
-        Step 1b1 is repeated until a valid email address if entered.
+        Step 1b1 is repeated until a valid email address is entered.
+        
+        Use case resumes at step 2.
 
 **Use case: UC04 — List all persons**
 


### PR DESCRIPTION
edit,
* grammatical errors in case UC03
* formatting errors for extensions in UC03 to indicate where the use case resumes to after an extension case
