### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ src/test/data/ExportCommandTest/filteredAddressBook.json
 docs/_site/
 docs/_markbind/logs/
 
+# Markbind generated files
+_markbind/
+
 #VSCode files
 .vscode/
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ hs_err_pid[0-9]*.log
 
 # Test sandbox files
 src/test/data/sandbox/
+src/test/data/ExportCommandTest/addressbookdata/
+src/test/data/ExportCommandTest/filteredAddressBook.json
 
 # MacOS custom attributes files created by Finder
 .DS_Store


### PR DESCRIPTION
Now, sandbox files generated by tests will not be pushed to the upstream repository.

Lets keep the upstream repository free of test sandbox files.