### PR TITLE
Build: Enable Assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,4 +76,8 @@ shadowJar {
     archiveFileName = 'avengersassemble.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
(for week 10 tutorial)
Now, assertions are enabled on gradle and we are able to utilize this important tool to test developer assumptions.

Lets improve build process