### PR TITLE
Lock size of exam list

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,7 +46,7 @@
         </StackPane>
             <HBox prefHeight="100.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
                <children>
-                  <VBox fx:id="examList" minWidth="300.0" prefWidth="300.0" styleClass="pane-with-border" HBox.hgrow="ALWAYS">
+                  <VBox fx:id="examList" minWidth="250.0" prefHeight="100.0" prefWidth="250.0" styleClass="pane-with-border" HBox.hgrow="NEVER">
                      <children>
                         <StackPane fx:id="examListPanelPlaceholder" VBox.vgrow="ALWAYS" />
                      </children>


### PR DESCRIPTION
Fixes #228 
Lock the size of exam list
Currently, the size of the exam list expands as the app size increases. Exam data should never be too long so it makes sense to lock the size of the exam list. So that the personslist can take up more space. This makes the UI look cleaner as well. 