### PR TITLE
Change SelectExamCommand to use index instead of names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddScoreCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddScoreCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.isAnyNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.HashMap;
 import java.util.List;
@@ -43,6 +44,7 @@ public class AddScoreCommand extends Command {
      * Creates an AddScoreCommand to add the specified {@code Score} to the person at the specified {@code Index}.
      */
     public AddScoreCommand(Index targetIndex, Score score) {
+        requireAllNonNull(targetIndex, score);
         this.targetIndex = targetIndex;
         this.score = score;
     }

--- a/src/main/java/seedu/address/logic/commands/ImportExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportExamCommand.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.opencsv.CSVParser;
 import com.opencsv.CSVParserBuilder;
@@ -16,10 +17,10 @@ import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvException;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddScoreCommandParser;
 import seedu.address.logic.parser.FindCommandParser;
-import seedu.address.logic.parser.SelectExamCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Score;
@@ -212,12 +213,22 @@ public class ImportExamCommand extends Command {
      */
     private static boolean executeSelectExam(Model model, Object examName) {
         try {
+            // Find the index of the exam with the given name
+            Index examIndex = Index.fromZeroBased(
+                IntStream.range(0, model.getExamList().size())
+                    .filter(i -> model.getExamList().get(i).getName().equals(examName.toString()))
+                    .findFirst()
+                    .orElse(-1)
+            );
+
+            // If the exam was not found, throw an exception
+            if (examIndex.getZeroBased() == -1) {
+                throw new CommandException("Exam not found");
+            }
+
             // Select the exam
-            SelectExamCommandParser selectExamCommandParser = new SelectExamCommandParser();
-            SelectExamCommand selectExamCommand = selectExamCommandParser.parse(PREFIX_SELECT_EXAM + examName);
+            SelectExamCommand selectExamCommand = new SelectExamCommand(examIndex);
             selectExamCommand.execute(model);
-        } catch (ParseException parseException) {
-            return true;
         } catch (CommandException commandException) {
             addToErrorReport(examName.toString(), commandException.getMessage());
             return true;

--- a/src/main/java/seedu/address/logic/commands/SelectExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectExamCommand.java
@@ -1,51 +1,48 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.exam.Exam;
 
-
 /**
- * Selects an exam from the address book.
+ * Selects an exam identified using it's displayed index from the address book.
  */
 public class SelectExamCommand extends Command {
 
     public static final String COMMAND_WORD = "selectExam";
 
-    public static final String MESSAGE_USAGE = "selectExam: Selects the exam by its name. "
-        + "Parameters: " + PREFIX_NAME + " NAME\n"
-        + "Example: selectExam " + PREFIX_NAME + "Midterm";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Selects the exam identified by the index number used in the displayed exam list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_SUCCESS = "Exam selected: %1$s";
-    public static final String MESSAGE_EXAM_NOT_FOUND = "Exam not found";
+    public static final String MESSAGE_SELECT_EXAM_SUCCESS = "Selected Exam: %1$s";
 
-    private final String targetExamName;
+    private final Index targetIndex;
 
-    /**
-     * Creates a SelectExamCommand to select the specified {@code Exam}
-     */
-    public SelectExamCommand(String examName) {
-        this.targetExamName = examName;
+    public SelectExamCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Exam> examList = model.getExamList();
-        if (examList == null || examList.isEmpty()) {
-            throw new CommandException(MESSAGE_EXAM_NOT_FOUND);
-        }
-        for (Exam exam : examList) {
-            if (exam.getName().equals(targetExamName)) {
-                model.selectExam(exam);
-                return new CommandResult(String.format(MESSAGE_SUCCESS, exam));
-            }
+        requireNonNull(model);
+        List<Exam> lastShownList = model.getExamList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EXAM_DISPLAYED_INDEX);
         }
 
-        throw new CommandException(MESSAGE_EXAM_NOT_FOUND);
+        Exam examToSelect = lastShownList.get(targetIndex.getZeroBased());
+        model.selectExam(examToSelect);
+        return new CommandResult(String.format(MESSAGE_SELECT_EXAM_SUCCESS, examToSelect));
     }
 
     @Override
@@ -59,6 +56,13 @@ public class SelectExamCommand extends Command {
         }
 
         SelectExamCommand otherSelectExamCommand = (SelectExamCommand) other;
-        return targetExamName.equals(otherSelectExamCommand.targetExamName);
+        return targetIndex.equals(otherSelectExamCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SelectExamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectExamCommandParser.java
@@ -1,10 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.stream.Stream;
-
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.SelectExamCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -19,26 +17,12 @@ public class SelectExamCommandParser implements Parser<SelectExamCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public SelectExamCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectExamCommand.MESSAGE_USAGE));
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new SelectExamCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectExamCommand.MESSAGE_USAGE), pe);
         }
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
-
-        String examName = ParserUtil.parseExamName(argMultimap.getValue(PREFIX_NAME).get());
-
-        return new SelectExamCommand(examName);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddScoreCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddScoreCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
@@ -4,10 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-// import java.util.Collections;
-// import java.util.List;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -26,11 +25,11 @@ public class SelectExamCommandTest {
         UserPrefs userPrefs = new UserPrefs();
         Model model = new ModelManager(addressBook, userPrefs);
 
-        SelectExamCommand command = new SelectExamCommand("Midterm");
+        SelectExamCommand command = new SelectExamCommand(Index.fromOneBased(1));
 
         CommandResult result = command.execute(model);
 
-        assertEquals(String.format(SelectExamCommand.MESSAGE_SUCCESS, exam), result.getFeedbackToUser());
+        assertEquals(String.format(SelectExamCommand.MESSAGE_SELECT_EXAM_SUCCESS, exam), result.getFeedbackToUser());
     }
 
     @Test
@@ -41,23 +40,23 @@ public class SelectExamCommandTest {
         UserPrefs userPrefs = new UserPrefs();
         Model model = new ModelManager(addressBook, userPrefs);
 
-        SelectExamCommand command = new SelectExamCommand("Final");
+        SelectExamCommand command = new SelectExamCommand(Index.fromOneBased(2));
 
         assertThrows(CommandException.class, () -> command.execute(model));
     }
 
     @Test
     public void equals_sameValues_returnsTrue() {
-        SelectExamCommand command1 = new SelectExamCommand("Midterm");
-        SelectExamCommand command2 = new SelectExamCommand("Midterm");
+        SelectExamCommand command1 = new SelectExamCommand(Index.fromOneBased(1));
+        SelectExamCommand command2 = new SelectExamCommand(Index.fromOneBased(1));
 
         assertEquals(command1, command2);
     }
 
     @Test
     public void equals_differentValues_returnsFalse() {
-        SelectExamCommand command1 = new SelectExamCommand("Midterm");
-        SelectExamCommand command2 = new SelectExamCommand("Final");
+        SelectExamCommand command1 = new SelectExamCommand(Index.fromOneBased(1));
+        SelectExamCommand command2 = new SelectExamCommand(Index.fromOneBased(2));
 
         assertNotEquals(command1, command2);
     }

--- a/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
@@ -71,7 +71,9 @@ public class SelectExamCommandTest {
     @Test
     void toStringTest() {
         SelectExamCommand selectExamCommand = new SelectExamCommand(Index.fromZeroBased(1));
-        assertEquals("SelectExamCommand{targetIndex=1}", selectExamCommand.toString());
+        assertEquals("seedu.address.logic.commands.SelectExamCommand{targetIndex="
+                     + "seedu.address.commons.core.index.Index{zeroBasedIndex=1}}",
+                     selectExamCommand.toString());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectExamCommandTest.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,19 +48,31 @@ public class SelectExamCommandTest {
     }
 
     @Test
-    public void equals_sameValues_returnsTrue() {
-        SelectExamCommand command1 = new SelectExamCommand(Index.fromOneBased(1));
-        SelectExamCommand command2 = new SelectExamCommand(Index.fromOneBased(1));
+    void equals() {
+        SelectExamCommand selectExamCommand1 = new SelectExamCommand(Index.fromZeroBased(1));
+        SelectExamCommand selectExamCommand2 = new SelectExamCommand(Index.fromZeroBased(1));
+        SelectExamCommand selectExamCommand3 = new SelectExamCommand(Index.fromZeroBased(2));
 
-        assertEquals(command1, command2);
+        // same object -> returns true
+        assertTrue(selectExamCommand1.equals(selectExamCommand1));
+
+        // same values -> returns true
+        assertTrue(selectExamCommand1.equals(selectExamCommand2));
+
+        // different types -> returns false
+        assertFalse(selectExamCommand1.equals(1));
+
+        // null -> returns false
+        assertFalse(selectExamCommand1.equals(null));
+
+        // different index -> returns false
+        assertFalse(selectExamCommand1.equals(selectExamCommand3));
     }
 
     @Test
-    public void equals_differentValues_returnsFalse() {
-        SelectExamCommand command1 = new SelectExamCommand(Index.fromOneBased(1));
-        SelectExamCommand command2 = new SelectExamCommand(Index.fromOneBased(2));
-
-        assertNotEquals(command1, command2);
+    void toStringTest() {
+        SelectExamCommand selectExamCommand = new SelectExamCommand(Index.fromZeroBased(1));
+        assertEquals("SelectExamCommand{targetIndex=1}", selectExamCommand.toString());
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ImportExamCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SelectExamCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonDetailContainsKeywordPredicate;
@@ -117,6 +118,11 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_deleteShown() throws Exception {
         assertTrue(parser.parseCommand("deleteshown") instanceof DeleteShownCommand);
+    }
+
+    @Test
+    public void parseCommand_selectExam() throws Exception {
+        assertTrue(parser.parseCommand("selectExam 1") instanceof SelectExamCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SelectExamCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SelectExamCommandParserTest.java
@@ -1,15 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.SelectExamCommand;
-import seedu.address.model.exam.Exam;
 
 public class SelectExamCommandParserTest {
 
@@ -17,29 +15,28 @@ public class SelectExamCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsSelectCommand() {
-        assertParseSuccess(parser, " " + PREFIX_NAME + "Midterm", new SelectExamCommand("Midterm"));
+        assertParseSuccess(parser, "1", new SelectExamCommand(Index.fromOneBased(1)));
     }
 
     @Test
     public void parse_validArgs_returnsSelectCommand2() {
-        assertParseSuccess(parser, " " + PREFIX_NAME + "Finals", new SelectExamCommand("Finals"));
-    }
-
-    @Test
-    public void parse_multipleRepeatedFields_failure() {
-        // multiple names
-        assertParseFailure(parser, " " + PREFIX_NAME + "Midterm " + PREFIX_NAME + "Finals",
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+        assertParseSuccess(parser, "2", new SelectExamCommand(Index.fromOneBased(2)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectExamCommand.MESSAGE_USAGE);
 
-        // no name prefix
+        // no index provided
         assertParseFailure(parser, "", expectedMessage);
 
-        // empty name
-        assertParseFailure(parser, " " + PREFIX_NAME + " ", Exam.MESSAGE_CONSTRAINTS);
+        // non-integer index
+        assertParseFailure(parser, "a", expectedMessage);
+
+        // zero index
+        assertParseFailure(parser, "0", expectedMessage);
+
+        // negative index
+        assertParseFailure(parser, "-1", expectedMessage);
     }
 }


### PR DESCRIPTION
SelectExamCommand currently uses names as a prefix to identify the exam to be selected. To make the application more user friendly, lets change the command to use exam indexes instead of names to identify the exam

Fixes #240 
