### PR TITLE
Update Spacing in UI and printing of persons

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -56,7 +56,12 @@ public class Messages {
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         builder.append("; Scores: ");
-        person.getScores().forEach((exam, score) -> builder.append(exam).append(": ").append(score).append(", "));
+        person.getScores().forEach((exam, score) -> builder.append("[ ")
+                                        .append(exam.getName()).append(": ")
+                                        .append(score).append(" / ").append(exam.getMaxScore())
+                                        .append(" ] ")
+        );
+        builder.append(";");
         return builder.toString();
     }
 

--- a/src/main/resources/view/ExamListCard.fxml
+++ b/src/main/resources/view/ExamListCard.fxml
@@ -28,12 +28,8 @@
         </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$exam_name" />
       </HBox>
-         <HBox alignment="CENTER_LEFT" spacing="5">
-            <children>
-               <Label text="Max Score: " />
-            <Label fx:id="maxScore" styleClass="cell_small_label" text="\$maxScore" />
-            </children>
-         </HBox>
+         <Label text="Max Score: " styleClass="cell_small_label"/>
+      <Label fx:id="maxScore" styleClass="cell_small_label" text="\$maxScore" />
     </VBox>
       <rowConstraints>
          <RowConstraints />


### PR DESCRIPTION
Fix max_scores cutting off when having more than 5 digits.
Fix incorrect formatting of persons when printing in results after command execution.

Fixes #282 