### PR TITLE
Decrease overzealous autotag

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -306,10 +306,10 @@ For the `edit` command, the parser will add or update the `Matric` field of the 
 
 ### Automatic Tagging of Persons
 
-Tags are automatically added during the parsing of the `add` command. The tags are based on the `Matric`, `Studio` and `Reflection` fields of the person being added.
+A `student` tag is automatically added during the parsing of the `add` command based on the presence of the `Matric` field of the person being added.
 
 #### Implementation Details
-During the parsing of the `add` command, the parser will check if the `Matric`, `Studio` or `Reflection` fields match a pattern that corresponds to them being a student, teaching assistant (TA), or course instructor.
+During the parsing of the `add` command, the parser will check if the `Matric` field is present, meaning they are a student.
 The parser also generates `Tag` objects based on the user input. The existing tags are updated with the new automatically generated tag.
 
 The activity diagram is as follows:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -236,12 +236,10 @@ Adds a person to your contact list. The person's details are now stored in the a
 
 </box>
 
-> **Note:** The following tags will be automatically added to the person if the following conditions are met:
-> 1. `student`: If matriculation number, studio, and reflection fields are present;
-> 2. `TA`: If matriculation number and one of either studio or reflection fields are present;
-> 3. `instructor`: If none of the three fields are present.
->
+> **Note:** 
+> For your convenience, a `student` tag will automatically be added to a contact if they are added with a matriculation number.
 > You are free to edit or remove the tags after the person is added with the [`edit`](#editing-a-person--edit) command.
+> For example, a student TA can be added with the `student` tag, and then the `TA` tag can be added to indicate that they are a TA.
 
 **Example:**
 `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 m/A1234567Z s/S1 r/R2`<br>

--- a/docs/diagrams/AutomaticTaggingActivityDiagram.puml
+++ b/docs/diagrams/AutomaticTaggingActivityDiagram.puml
@@ -3,19 +3,8 @@ start
 :User adds a new person;
 
 if () then ([has Matric])
-  if () is ([has both Studio and Reflection]) then
     :Add new "student" tag;
-  else ([else])
-    if () is ([has either Studio \n or Reflection \n but not both]) then
-      :Add new "TA" tag;
-    else ([else])
-    endif
-  endif
 else ([else])
-  if () is ([No Studio and Reflection]) then
-    :Add new "instructor" tag;
-  else ([else])
-  endif
 endif
 stop
 @enduml

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -66,7 +66,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         // Update the tagList automatically
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        tagList = autoTag(tagList, matric, reflection, studio);
+        tagList = autoTag(tagList, matric);
 
         Person person = new Person(name, phone, email, address, tagList, matric, reflection, studio, scores);
 
@@ -77,16 +77,12 @@ public class AddCommandParser implements Parser<AddCommand> {
      * Automatically adds a tag to the tagList based on the presence of matric, reflection and studio.
      * @param tagList the list of tags to be updated
      * @param matric the matric number of the person
-     * @param reflection the reflection of the person
-     * @param studio the studio of the person
      * @return
      */
-    private Set<Tag> autoTag(Set<Tag> tagList, Matric matric, Reflection reflection, Studio studio) {
+    private Set<Tag> autoTag(Set<Tag> tagList, Matric matric) {
         boolean isMatricPresent = !Matric.isEmptyMatric(matric.matricNumber);
-        boolean isReflectionPresent = !Reflection.isEmptyReflection(reflection.reflection);
-        boolean isStudioPresent = !Studio.isEmptyStudio(studio.studio);
 
-        Optional<Tag> autoTag = createTag(isMatricPresent, isReflectionPresent, isStudioPresent);
+        Optional<Tag> autoTag = createTag(isMatricPresent);
         autoTag.ifPresent(tagList::add);
 
         return tagList;
@@ -95,17 +91,11 @@ public class AddCommandParser implements Parser<AddCommand> {
     /**
      * Creates a tag based on the presence of matric, reflection and studio.
      * @param isMatricPresent boolean whether a Matric number is present.
-     * @param isReflectionPresent boolean whether a Reflection is present.
-     * @param isStudioPresent boolean whether a Studio is present.
      * @return an Optional Tag based on the presence of matric, reflection and studio.
      */
-    private Optional<Tag> createTag(boolean isMatricPresent, boolean isReflectionPresent, boolean isStudioPresent) {
-        if (isMatricPresent && isReflectionPresent && isStudioPresent) {
+    private Optional<Tag> createTag(boolean isMatricPresent) {
+        if (isMatricPresent) {
             return Optional.of(new Tag("student"));
-        } else if (isMatricPresent && (isReflectionPresent ^ isStudioPresent)) {
-            return Optional.of(new Tag("TA"));
-        } else if (!isMatricPresent && !isReflectionPresent && !isStudioPresent) {
-            return Optional.of(new Tag("instructor"));
         }
         return Optional.empty();
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -32,8 +32,6 @@ public class CommandTestUtil {
     public static final String VALID_TAG_TA = "TA";
     public static final String VALID_TAG_INSTRUCTOR = "instructor";
     public static final String VALID_DESC_STUDENT = " " + PREFIX_TAG + VALID_TAG_STUDENT;
-    public static final String VALID_DESC_TA = " " + PREFIX_TAG + VALID_TAG_TA;
-    public static final String VALID_DESC_INSTRUCTOR = " " + PREFIX_TAG + VALID_TAG_INSTRUCTOR;
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -38,9 +38,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_REFLECTION_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDIO_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_INSTRUCTOR;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_STUDENT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TA;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
@@ -217,7 +215,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_reflectionMissing_success() {
         // no reflection means TA
-        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_FRIEND, VALID_TAG_TA)
+        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_FRIEND, VALID_TAG_STUDENT)
                 .withMatric(VALID_MATRIC_NUMBER_AMY).withReflection("").build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
                         + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND + MATRIC_DESC_AMY + STUDIO_DESC_AMY,
@@ -227,7 +225,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_studioMissing_success() {
         // no studio means TA
-        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_FRIEND, VALID_TAG_TA)
+        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_FRIEND, VALID_TAG_STUDENT)
                 .withMatric(VALID_MATRIC_NUMBER_AMY).withStudio("").build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
                         + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND + MATRIC_DESC_AMY + REFLECTION_DESC_AMY,
@@ -248,7 +246,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_tagAndStudioMissing_success() {
         // zero tags; no studio
-        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_TA).withMatric(VALID_MATRIC_NUMBER_AMY)
+        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_STUDENT).withMatric(VALID_MATRIC_NUMBER_AMY)
                 .withStudio("").build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
                         + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + MATRIC_DESC_AMY + REFLECTION_DESC_AMY,
@@ -285,7 +283,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_matricAndStudioAndReflectionMissing_success() {
-        Person expectedPerson = new PersonBuilder(AMY).withTags(VALID_TAG_INSTRUCTOR)
+        Person expectedPerson = new PersonBuilder(AMY).withTags()
                 .withMatric("").withReflection("").withStudio("").build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
                         + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,


### PR DESCRIPTION
Prevents feature flaw and minimizes false positives.
Now, auto tagging is solely based on the presence of matriculation number.
fixes #297 

## Notable Changes
1. Updated UG to reflect new behavior and emphasized the possibility of a student being a TA as well.
2. Modified unit tests.