### PR TITLE
Modify AddCommand to throw more specfic exceptions

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,6 +21,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_MISSING_COMPULSORY_PREFIXES = "Missing compulsory prefixes: ";
     public static final String MESSAGE_NO_EXAM_SELECTED = "No exam selected. Please select an exam first.";
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_COMPULSORY_PREFIXES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
@@ -11,9 +12,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDIO;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -46,9 +49,18 @@ public class AddCommandParser implements Parser<AddCommand> {
                         args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_TAG, PREFIX_MATRIC_NUMBER, PREFIX_REFLECTION, PREFIX_STUDIO);
 
-        if (!arePrefixesPresent(
-                argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
+        List<Prefix> missingCompulsoryPrefixes = findMissingCompulsoryPrefixes(argMultimap, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_ADDRESS);
+
+        if (missingCompulsoryPrefixes.size() > 0) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                                    MESSAGE_MISSING_COMPULSORY_PREFIXES
+                                                    + missingCompulsoryPrefixes.stream()
+                                                        .map(Prefix::toString)
+                                                        .collect(Collectors.joining(", "))));
+        }
+
+        if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
@@ -140,6 +152,12 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    private static List<Prefix> findMissingCompulsoryPrefixes(ArgumentMultimap argumentMultimap,
+            Prefix... compulsoryPrefixes) {
+        return Stream.of(compulsoryPrefixes).filter(prefix -> argumentMultimap.getValue(prefix).isEmpty())
+                                            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/seedu/address/model/exam/Exam.java
+++ b/src/main/java/seedu/address/model/exam/Exam.java
@@ -3,8 +3,6 @@ package seedu.address.model.exam;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Score;
 
 /**
@@ -72,12 +70,14 @@ public class Exam {
      * Returns true if a given string is a valid exam score.
      */
     public static boolean isValidExamScoreString(String test) {
-        try {
-            Score score = ParserUtil.parseScore(test);
-            return score.getScore() > 0;
-        } catch (ParseException e) {
+        if (!test.matches(Score.VALIDATION_REGEX)) {
             return false;
         }
+        Double.parseDouble(test);
+        if (Double.parseDouble(test) <= 0) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Score.java
+++ b/src/main/java/seedu/address/model/person/Score.java
@@ -35,6 +35,9 @@ public class Score implements Comparable<Score> {
 
     /**
      * Returns true if a given string is a valid score.
+     * IMPT: This method breaks when the score has more than 9 digits as
+     * the string representation of the score will be in scientific notation. However, scores are
+     * limited to 2 decimal places and 9 digits total.
      */
     public static boolean isValidScore(double test) {
         String str = Double.toString(test);

--- a/src/main/java/seedu/address/storage/JsonAdaptedExam.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExam.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.exam.Exam;
+import seedu.address.model.person.Score;
 
 class JsonAdaptedExam {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Exam's %s field is missing!";
+
     private final String name;
     private final String maxScore;
 
@@ -42,6 +45,23 @@ class JsonAdaptedExam {
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
     public Exam toModelType() throws IllegalValueException {
-        return new Exam(ParserUtil.parseExamName(name), ParserUtil.parseScore(maxScore));
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "name"));
+        }
+        if (Exam.isValidExamName(name) == false) {
+            throw new IllegalValueException(Exam.MESSAGE_CONSTRAINTS);
+        }
+        if (maxScore == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "maxScore"));
+        }
+        if (Exam.isValidExamScoreString(maxScore) == false) {
+            throw new IllegalValueException(Exam.MESSAGE_CONSTRAINTS);
+        }
+
+        final String modelName = this.name;
+        final Score modelMaxScore = new Score(Double.parseDouble(this.maxScore));
+
+        return new Exam(modelName, modelMaxScore);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_COMPULSORY_PREFIXES;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -294,27 +295,32 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_COMPULSORY_PREFIXES
+                        + PREFIX_NAME.toString()));
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_COMPULSORY_PREFIXES
+                        + PREFIX_PHONE.toString()));
 
         // missing email prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_COMPULSORY_PREFIXES
+                        + PREFIX_EMAIL.toString()));
 
         // missing address prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_COMPULSORY_PREFIXES
+                        + PREFIX_ADDRESS.toString()));
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_COMPULSORY_PREFIXES
+                        + PREFIX_NAME.toString() + ", " + PREFIX_PHONE.toString() + ", "
+                        + PREFIX_EMAIL.toString() + ", " + PREFIX_ADDRESS.toString()));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedExamTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedExamTest.java
@@ -1,0 +1,43 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.exam.Exam;
+import seedu.address.model.person.Score;
+
+public class JsonAdaptedExamTest {
+
+    @Test
+    public void toModelType_validExamDetails_returnsExam() throws Exception {
+        JsonAdaptedExam exam = new JsonAdaptedExam("Math", "100");
+        assertEquals(new Exam("Math", new Score(100)), exam.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidName_throwsIllegalValueException() {
+        JsonAdaptedExam exam = new JsonAdaptedExam("", "100");
+        assertThrows(IllegalValueException.class, exam::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullName_throwsIllegalValueException() {
+        JsonAdaptedExam exam = new JsonAdaptedExam(null, "100");
+        assertThrows(IllegalValueException.class, exam::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidScore_throwsIllegalValueException() {
+        JsonAdaptedExam exam = new JsonAdaptedExam("Math", "-1");
+        assertThrows(IllegalValueException.class, exam::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullScore_throwsIllegalValueException() {
+        JsonAdaptedExam exam = new JsonAdaptedExam("Math", null);
+        assertThrows(IllegalValueException.class, exam::toModelType);
+    }
+}


### PR DESCRIPTION
Currently, the AddCommandParser throws a very generic message when compulsory prefixes are missing from the user input. Lets change it so that it indicates which compulsory prefix is missing. This will also benefit the Import Command when it generates its error report.

Fixes #292 