### PR TITLE
Limit Mean and Median to show 2DP

### DIFF
--- a/src/main/java/seedu/address/model/ScoreStatistics.java
+++ b/src/main/java/seedu/address/model/ScoreStatistics.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import java.text.DecimalFormat;
+
 /**
  * Represents the statistics of a list of scores.
  */
@@ -36,7 +38,8 @@ public class ScoreStatistics {
         if (mean == -1) {
             return "No scores available";
         }
-        return "Mean: " + mean
-                + ", Median: " + median;
+        DecimalFormat df = new DecimalFormat("0.##");
+        return "Mean: " + df.format(mean)
+                + ", Median: " + df.format(median);
     }
 }

--- a/src/test/java/seedu/address/model/ScoreStatisticsTest.java
+++ b/src/test/java/seedu/address/model/ScoreStatisticsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+
 class ScoreStatisticsTest {
 
     @Test
@@ -23,7 +24,7 @@ class ScoreStatisticsTest {
     @Test
     void testToString() {
         ScoreStatistics stats = new ScoreStatistics(50.0, 50.0);
-        String expected = "Mean: 50.0, Median: 50.0";
+        String expected = "Mean: 50, Median: 50";
         assertEquals(expected, stats.toString());
 
         ScoreStatistics noScoresStats = new ScoreStatistics();


### PR DESCRIPTION
![image](https://github.com/AY2324S2-CS2103T-T10-1/tp/assets/103935416/35472c25-80df-40b8-aff3-c60603feff6b)
Currently, it is possible for the mean and median feature of the application to display numbers like these. Lets change it so that it is limited to 2 decimal places. 