### PR TITLE
Fix: typos in success messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "All persons and exams have been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -23,7 +23,7 @@ public class DeleteCommand extends Command {
             + "Parameter: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted person: %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteExamCommand.java
@@ -23,7 +23,7 @@ public class DeleteExamCommand extends Command {
             + "Parameter: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_EXAM_SUCCESS = "Deleted Exam: %1$s";
+    public static final String MESSAGE_DELETE_EXAM_SUCCESS = "Deleted exam: %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Avengers Assemble as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -37,7 +37,7 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts with a specified aspect "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons with a specified aspect "
             + "containing specified keyword (case-insensitive) or\n"
             + "which meets the criteria with the specified value (positive-integer)\n"
             + "and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -30,11 +30,11 @@ public class ImportCommand extends Command {
 
     public static final String COMMAND_WORD = "import";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports contacts from specified filepath."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports persons from specified filepath."
             + " Must be an absolute CSV file path. Parameter: FILEPATH\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_IMPORT + "C:usr/lib/text.csv";
     private static final String MESSAGE_ARGUMENTS = "filePath: %s";
-    private static final String MESSAGE_IMPORT_SUCCESS = "Imported Contacts from: %s";
+    private static final String MESSAGE_IMPORT_SUCCESS = "Imported persons from: %s";
     private static final String MESSAGE_DATA_LOAD_ERROR = "Unable to load data from %s";
     private static final String MESSAGE_PARSE_ERROR = "Invalid data format in %s";
     private final Path filePath;

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -33,8 +33,8 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports persons from specified filepath."
             + " Must be an absolute CSV file path. Parameter: FILEPATH\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_IMPORT + "C:usr/lib/text.csv";
+    public static final String MESSAGE_IMPORT_SUCCESS = "Imported persons from: %s";
     private static final String MESSAGE_ARGUMENTS = "filePath: %s";
-    private static final String MESSAGE_IMPORT_SUCCESS = "Imported persons from: %s";
     private static final String MESSAGE_DATA_LOAD_ERROR = "Unable to load data from %s";
     private static final String MESSAGE_PARSE_ERROR = "Invalid data format in %s";
     private final Path filePath;

--- a/src/main/java/seedu/address/logic/commands/ImportExamScoresCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportExamScoresCommand.java
@@ -22,17 +22,18 @@ import seedu.address.model.person.Score;
 public class ImportExamScoresCommand extends Command {
 
     public static final String COMMAND_WORD = "importExamScores";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports exams from specified filepath."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports exam scores from specified filepath."
             + " Must be an absolute CSV file path. Parameter: "
             + PREFIX_IMPORT + "FILEPATH\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_IMPORT + "C:usr/lib/text.csv";
     public static final String MESSAGE_SCORE_NOT_NUMBER = "Score for %s is not a number";
     public static final String MESSAGE_PERSON_DOES_NOT_EXIST = "Person does not exist";
-    public static final String MESSAGE_SUCCESS = "Imported exams from: %s";
+    public static final String MESSAGE_SUCCESS = "Imported exam scores from: %s";
     public static final String MESSAGE_DUPLICATE_EXAM =
             "Duplicate exam header. Only the records of the first exam will be imported if present.";
     public static final String EXAM_HEADER = "Exam:";
-    public static final String PREFIX_ERROR_REPORT = "\nBelow are the errors that occurred while importing exams:\n";
+    public static final String PREFIX_ERROR_REPORT =
+            "\nBelow are the errors that occurred while importing exam scores:\n";
     public static final String MESSAGE_EXAM_DOES_NOT_EXIST = "Exam does not exist";
     public static final String MESSAGE_GRADE_TOO_HIGH = "Grade for %s exceeds maximum score";
     public static final String HEADER_EMAIL = "email";

--- a/src/main/java/seedu/address/logic/commands/SelectExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectExamCommand.java
@@ -23,7 +23,7 @@ public class SelectExamCommand extends Command {
             + "Parameter: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_SELECT_EXAM_SUCCESS = "Selected Exam: %1$s";
+    public static final String MESSAGE_SELECT_EXAM_SUCCESS = "Selected exam: %1$s";
 
     private final Index targetIndex;
 

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -32,8 +32,8 @@ public class ImportCommandTest {
         Path filePath = Paths.get("src/test/data/ImportCommandTest/valid.csv");
         ImportCommand importCommand = new ImportCommand(filePath);
         CommandResult commandResult = importCommand.execute(model);
-        assertEquals(
-                String.format("Imported Contacts from: %s", filePath.toString()), commandResult.getFeedbackToUser());
+        assertEquals(String.format(ImportCommand.MESSAGE_IMPORT_SUCCESS, filePath.toString()),
+                commandResult.getFeedbackToUser());
     }
     @Test
     public void execute_convertToAddCommandInput_success() {


### PR DESCRIPTION
Now the messages for commands are standardized.

Lets standardize messages.

## Changes
1. Fixed erroneous success messages for importExamScores 
2. remove references to 'address book' because our product is much more than an address book. it is avengers assemble.
3. standardized capitalization for success messages
4. changed all references of `contact` to `person` instead
5. remove magic literal for `import` command