### PR TITLE
BugFix: Bug Fixes from PED

### DIFF
--- a/src/main/java/seedu/address/commons/util/CsvUtil.java
+++ b/src/main/java/seedu/address/commons/util/CsvUtil.java
@@ -100,10 +100,20 @@ public class CsvUtil {
             throws DataLoadingException {
         // first check if the compulsory parameters are present in the header
         checkCompulsoryParameters(compulsoryParameters, headers);
-        return IntStream.range(0, headers.size())
-                .filter(i ->
-                        !compulsoryParameters.contains(headers.get(i)) && !optionalParameters.contains(headers.get(i)))
-                .boxed().collect(Collectors.toList());
+        List<Integer> columnsToSkip = new ArrayList<>();
+        HashSet<String> uniqueHeaders = new HashSet<>();
+        for (int i = 0; i < headers.size(); i++) {
+            if ((!compulsoryParameters.contains(headers.get(i))
+                    && !optionalParameters.contains(headers.get(i)))
+                    | uniqueHeaders.contains(headers.get(i))) {
+                columnsToSkip.add(i);
+            } else {
+                uniqueHeaders.add(headers.get(i));
+            }
+
+        }
+
+        return columnsToSkip;
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/CsvUtil.java
+++ b/src/main/java/seedu/address/commons/util/CsvUtil.java
@@ -69,13 +69,17 @@ public class CsvUtil {
         String errorMsgs = "";
         try {
             CSVReader reader = new CSVReaderBuilder(new FileReader(filePath.toString())).build();
-            List<String> headers = List.of(reader.readNext()); // first line should be headers
-            List<Integer> columnsToSkip = columnsToSkip(headers, compulsoryParameters, optionalParameters);
-            List<String[]> rows = reader.readAll();
-            Pair<List<Map<String, String>>, String> result = parseData(rows, headers, columnsToSkip);
-            data = result.getKey();
-            errorMsgs = result.getValue();
-            nullableData = Optional.of(data);
+            Optional<String[]> headers = Optional.ofNullable(reader.readNext()); // first line should be headers
+            if (headers.isPresent()) {
+                List<String> headersList = List.of(headers.get());
+                List<Integer> columnsToSkip = columnsToSkip(headersList, compulsoryParameters, optionalParameters);
+                List<String[]> rows = reader.readAll();
+                Pair<List<Map<String, String>>, String> result = parseData(rows, headersList, columnsToSkip);
+                data = result.getKey();
+                errorMsgs = result.getValue();
+                nullableData = Optional.of(data);
+            }
+
             return new Pair<>(nullableData, errorMsgs);
         } catch (DataLoadingException | CsvException e) {
             return new Pair<>(nullableData, e.getMessage());

--- a/src/main/java/seedu/address/commons/util/CsvUtil.java
+++ b/src/main/java/seedu/address/commons/util/CsvUtil.java
@@ -15,8 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -37,9 +37,8 @@ public class ImportCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports persons from specified filepath."
             + " Must be an absolute CSV file path\n"
-            + "Parameters: filePath\n"
-            + "[" + PREFIX_IMPORT + "import]\n"
-            + "Example: " + COMMAND_WORD + PREFIX_IMPORT + "C:usr/lib/text.csv";
+            + "Parameters: " + PREFIX_IMPORT + "FILEPATH\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_IMPORT + "C:usr/lib/text.csv";
     private static final String MESSAGE_IMPORT_SUCCESS = "Imported persons successfully!\n";
     private final Path filePath;
     private final AddCommandParser addCommandParser = new AddCommandParser();

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_IMPORT;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 import seedu.address.logic.commands.ImportCommand;
@@ -15,6 +16,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class ImportCommandParser implements Parser<ImportCommand> {
 
     private static final String MESSAGE_NOT_CSV = "File %s is not a csv file \nImport command only accepts csv files";
+
+    private static final String MESSAGE_INVALID_PATH = "Invalid file path: %s";
     /**
      * Parses the given {@code String} of arguments in the context of the {@code RemarkCommand}
      * and returns a {@code RemarkCommand} object for execution.
@@ -29,8 +32,13 @@ public class ImportCommandParser implements Parser<ImportCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
         }
+        Path path;
+        try {
+            path = ParserUtil.parseFilePath(argMultimap.getValue(PREFIX_IMPORT).orElse(""));
+        } catch (InvalidPathException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_PATH, e.getReason()));
+        }
 
-        Path path = ParserUtil.parseFilePath(argMultimap.getValue(PREFIX_IMPORT).orElse(""));
 
         if (!isCsvFile(path)) {
             throw new ParseException(String.format(MESSAGE_NOT_CSV, path.toString()));

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -41,7 +41,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
 
 
         if (!isCsvFile(path)) {
-            throw new ParseException(String.format(MESSAGE_NOT_CSV, path.toString()));
+            throw new ParseException(String.format(MESSAGE_NOT_CSV, path));
         }
         return new ImportCommand(path);
     }

--- a/src/test/data/ImportCommandTest/duplicateHeaders.csv
+++ b/src/test/data/ImportCommandTest/duplicateHeaders.csv
@@ -1,8 +1,8 @@
 name,phone,email,address,matric,reflection,studio,tags,email
-"Alice Pauline",94351253,alice@example.com,"123, Jurong West Ave 6, #08-111",A1111111A,R1,S1,friends,
-"Benson Meier",98765432,johnd@example.com,"311, Clementi Ave 2, #02-25",A2222222A,R2,S2,friends,
-"Carl Kurz",95352563,heinz@example.com,"wall street",A3333333A,R3,S3,,
-"Daniel Meier",87652533,cornelia@example.com,"10th street",A4444444A,R4,S4,friends,
-"Elle Meyer",9482224,werner@example.com,"michegan ave",A5555555A,R5,S5,,
-"Fiona Kunz",9482427,lydia@example.com,"little tokyo",A6666666A,R6,S6,,
-"George Best",9482442,anna@example.com,"4th street",A7777777A,R7,S7,,
+"Alice Pauline",94351253,alice@example.com,"123, Jurong West Ave 6, #08-111",A1111111A,R1,S1,friends,alice@example.com
+"Benson Meier",98765432,johnd@example.com,"311, Clementi Ave 2, #02-25",A2222222A,R2,S2,friends,johnd@example.com
+"Carl Kurz",95352563,heinz@example.com,"wall street",A3333333A,R3,S3,,heinz@example.com
+"Daniel Meier",87652533,cornelia@example.com,"10th street",A4444444A,R4,S4,friends,cornelia@example.com
+"Elle Meyer",9482224,werner@example.com,"michegan ave",A5555555A,R5,S5,,werner@example.com
+"Fiona Kunz",9482427,lydia@example.com,"little tokyo",A6666666A,R6,S6,,lydia@example.com
+"George Best",9482442,anna@example.com,"4th street",A7777777A,R7,S7,,anna@example.com

--- a/src/test/data/ImportCommandTest/duplicateHeaders.csv
+++ b/src/test/data/ImportCommandTest/duplicateHeaders.csv
@@ -1,0 +1,8 @@
+name,phone,email,address,matric,reflection,studio,tags,email
+"Alice Pauline",94351253,alice@example.com,"123, Jurong West Ave 6, #08-111",A1111111A,R1,S1,friends,
+"Benson Meier",98765432,johnd@example.com,"311, Clementi Ave 2, #02-25",A2222222A,R2,S2,friends,
+"Carl Kurz",95352563,heinz@example.com,"wall street",A3333333A,R3,S3,,
+"Daniel Meier",87652533,cornelia@example.com,"10th street",A4444444A,R4,S4,friends,
+"Elle Meyer",9482224,werner@example.com,"michegan ave",A5555555A,R5,S5,,
+"Fiona Kunz",9482427,lydia@example.com,"little tokyo",A6666666A,R6,S6,,
+"George Best",9482442,anna@example.com,"4th street",A7777777A,R7,S7,,

--- a/src/test/java/seedu/address/commons/util/CsvUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CsvUtilTest.java
@@ -68,6 +68,16 @@ public class CsvUtilTest {
     }
 
     @Test
+    public void readCsvFile_emptyCsv_success() throws IOException {
+        Optional<List<Map<String, String>>> expected = Optional.empty();
+        assertEquals(expected,
+                CsvUtil.readCsvFile(
+                        Paths.get("src/test/data/ImportCommandTest/empty.csv"),
+                        compulsoryParameters,
+                        optionalParameters).getKey());
+    }
+
+    @Test
     public void readCsvFile_extraHeader_success() throws IOException {
         String expected = "";
         assertEquals(expected,

--- a/src/test/java/seedu/address/commons/util/CsvUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CsvUtilTest.java
@@ -88,6 +88,16 @@ public class CsvUtilTest {
     }
 
     @Test
+    public void readCsvFile_duplicateHeader_success() throws IOException {
+        String expected = "";
+        assertEquals(expected,
+                CsvUtil.readCsvFile(
+                        Paths.get("src/test/data/ImportCommandTest/duplicateHeaders.csv"),
+                        compulsoryParameters,
+                        optionalParameters).getValue());
+    }
+
+    @Test
     public void checkCompulsoryParameters_missingCompulsoryParameter_failure() {
         assertThrows(DataLoadingException.class, () ->
                 CsvUtil.checkCompulsoryParameters(


### PR DESCRIPTION
Bug fix from PED

1) Now import Command properly displays its Usage message, with
a whitespace between import and i|

fixes #359 

2) ImportCommandParser now also checks for invalid characters in
filePath which is already caught by the InvalidPathException in
java

fixes #345 

3) Bug fix for when csv file to be imported is empty

Currently the readCsvFile method in CsvUtil only checks if the values
are empty but not if the rows themselves are empty. Now, it is
handled by readCsvFile to return an empty nullableData and
empty report

fixes #348

4) Bug fix for duplicate headers when they have the same value

For the case of duplicate headers, there is a bug in which when
there are 2 email coloumns with the same value, the person is not
added to the addressBook. (As stated in the PE-D, issue #362).

This is fixed by now correctly ignoring the duplicate column

fixes #362 