### PR TITLE
Reformat Manual Testing Section in DG to follow standard formatting

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -2583,29 +2583,37 @@ Expected: The GUI closes and the application exits.
 
 #### Adding an Exam: `addExam`
 
-##### Adding an Exam with Valid Data
+**Command:** `addExam`<br>
+**More information on usage:** <a href="UserGuide.md#addexam">Adding an Exam</a>
 
-1. Prerequisites: No exams in the address book.
+1. Adding an Exam with Valid Data
 
-2. Test case: `addExam n|Midterm s|100`<br>
-   Expected: New exam is added to the address book. Status message shows the exam added.
+   * **Prerequisites:**
+       * No exams in the address book.
+         <br><br>
+   * **Test case:** `addExam n|Midterm s|100`<br>
+     **Expected:** New exam is added to the address book. Status message shows the exam added.
+     <br><br>
+   * **Other test cases to try:** `addExam n|Final s|100`<br>
+     **Expected:** New exam is added to the address book. Status message shows the exam added.
+     <br><br>
 
-3. Other test cases to try: `addExam n|Final s|100`<br>
-   Expected: New exam is added to the address book. Status message shows the exam added.
+2. Adding an Exam that Already Exists
 
-##### Adding an Exam that Already Exists
+   * **Prerequisites:**
+       * An exam of name: Final, Score: 100 exists in the address book.
+       <br><br>
+   * **Test case:** `addExam n|Final s|100`<br>
+     **Expected:** Error message shown in the error report. No change in the address book.
+     <br><br>
 
-1. Prerequisites: An exam of name: Final, Score: 100 exists in the address book.
+3. Adding an Exam with Missing Fields
 
-2. Test case: `addExam n|Final s|100`<br>
-   Expected: Error message shown in the error report. No change in the address book.
-
-##### Adding an Exam with Missing Fields
-
-1. Pre-requisite: No exams in the address book.
-
-2. Test case: `addExam n|Final` (missing score)<br>
-     Expected: Error message shown in the error report. No change in the address book.
+   * **Prerequisites:** 
+       * No exams in the address book.
+         <br><br>
+   * **Test case (missing score):** `addExam n|Final`<br>
+     **Expected:** Error message shown in the error report. No change in the address book.
 
 <br>
 
@@ -2613,19 +2621,25 @@ Expected: The GUI closes and the application exits.
 
 #### Deleting an Exam: `deleteExam`
 
-1. Prerequisites: Exactly one exam in the address book. Hence, exam has an index of 1.
+**Command:** `deleteExam`<br>
+**More information on usage:** <a href="UserGuide.md#deleteexam">Deleting an Exam</a>
 
-2. Test case: `deleteExam 1`<br>
-   Expected: First exam is deleted from the address book. Status message shows the exam deleted.
+1. Deleting an Exam
 
-3. Test case: `deleteExam 0`<br>
-   Expected: No exam is deleted. Error message shown. No change in the address book.
-
-4. Test case: `deleteExam 2` (index out of bounds)<br>
-   Expected: No exam is deleted. Error message shown. No change in the address book.
-
-5. Test case: `deleteExam` (no index)<br>
-   Expected: No exam is deleted. Error message shown. No change in the address book.
+    * **Prerequisites:** 
+        * Exactly one exam in the address book. Hence, exam has an index of 1.
+          <br><br>
+    * **Test case:** `deleteExam 1`<br>
+      **Expected:** First exam is deleted from the address book. Status message shows the exam deleted.
+      <br><br>
+    * **Test case:** `deleteExam 0`<br>
+      **Expected:** No exam is deleted. Error message shown. No change in the address book.
+      <br><br>
+    * **Test case (index out of bounds):** `deleteExam 2`<br>
+      **Expected:** No exam is deleted. Error message shown. No change in the address book.
+      <br><br>
+    * **Test case (no index):** `deleteExam`<br>
+      **Expected:** No exam is deleted. Error message shown. No change in the address book.
 
 <br>
 
@@ -2633,31 +2647,45 @@ Expected: The GUI closes and the application exits.
 
 #### Selecting an Exam: `selectExam`
 
-1. Prerequisites: Exactly one exam in the address book. Hence, exam has an index of 1.
+**Command:** `selectExam`<br>
+**More information on usage:** <a href="UserGuide.md#selectexam">Selecting an Exam</a>
 
-2. Test case: `selectExam 1`<br>
-   Expected: First exam is selected. Status message shows the exam selected.
+1. Selecting an exam
 
-3. Test case: `selectExam 0`<br>
-   Expected: No exam is selected. Error message shown. No change in the address book.
+    * **Prerequisites:** 
+        * Exactly one exam in the address book. Hence, exam has an index of 1.
+          <br><br>
+    * **Test case:** `selectExam 1`<br>
+      **Expected:** First exam is selected. Status message shows the exam selected.
+      <br><br>
+    * **Test case:** `selectExam 0`<br>
+      **Expected:** No exam is selected. Error message shown. No change in the address book.
+      <br><br>
+    * **Test case (index out of bounds):** `selectExam 2`<br>
+      **Expected:** No exam is selected. Error message shown. No change in the address book.
+      <br><br>
+    * **Test case (no index):** `selectExam`<br>
+      **Expected:** No exam is selected. Error message shown. No change in the address book.
 
-4. Test case: `selectExam 2` (index out of bounds)<br>
-   Expected: No exam is selected. Error message shown. No change in the address book.
-
-5. Test case: `selectExam` (no index)<br>
-   Expected: No exam is selected. Error message shown. No change in the address book.
+<br>
 
 <div id="test_deselectexam"></div>
 
 #### Deselecting an Exam: `deselectExam`
 
-1. Prerequisites: An exam has been selected.
+**Command:** `deselectExam`<br>
+**More information on usage:** <a href="UserGuide.md#deselectexam">Deselecting an Exam</a>
 
-2. Test case: `deselectExam`<br>
-   Expected: Selected exam is deselected. Status message shows the exam deselected.
+1. Deselecting an Exam
 
-3. Test case: `deselectExam` (no exam selected)<br>
-   Expected: No exam is deselected. Error message shown. No change in the address book.
+    * **Prerequisites:** 
+        * An exam has been selected.
+          <br><br>
+    * **Test case:** `deselectExam`<br>
+      **Expected:** Selected exam is deselected. Status message shows the exam deselected.
+      <br><br>
+    * **Test case (no exam selected):** `deselectExam`<br>
+      **Expected:** No exam is deselected. Error message shown. No change in the address book.
 
 <br>
 
@@ -2729,7 +2757,7 @@ Expected: The GUI closes and the application exits.
 
     ```
     email,Exam:Midterm,Exam:Midterm
-   alexyeoh@example.com,50,60
+    alexyeoh@example.com,50,60
     ```
 
 3. Test case: `importExamScores /path/to/file.csv`


### PR DESCRIPTION
The parts that I have changed so far are:
- addExam
- selectExam
- deselectExam
- deleteExam